### PR TITLE
Stop the auto-save at a commit message editing

### DIFF
--- a/config/packages/init-auto-save-buffers-enhanced.el
+++ b/config/packages/init-auto-save-buffers-enhanced.el
@@ -6,6 +6,7 @@
 
 (setq auto-save-default nil
       auto-save-buffers-enhanced-cooperate-elscreen-p t
+      auto-save-buffers-enhanced-exclude-regexps '("COMMIT_EDITMSG")
       auto-save-buffers-enhanced-quiet-save-p t
       auto-save-buffers-enhanced-save-scratch-buffer-to-file-p t)
 (define-key global-map "\C-xas" 'auto-save-buffers-enhanced-toggle-activity)

--- a/config/packages/init-auto-save-buffers-enhanced.el
+++ b/config/packages/init-auto-save-buffers-enhanced.el
@@ -5,9 +5,9 @@
 (require 'auto-save-buffers-enhanced)
 
 (setq auto-save-default nil
-      auto-save-buffers-enhanced-save-scratch-buffer-to-file-p t
       auto-save-buffers-enhanced-cooperate-elscreen-p t
-      auto-save-buffers-enhanced-quiet-save-p t)
+      auto-save-buffers-enhanced-quiet-save-p t
+      auto-save-buffers-enhanced-save-scratch-buffer-to-file-p t)
 (define-key global-map "\C-xas" 'auto-save-buffers-enhanced-toggle-activity)
 (auto-save-buffers-enhanced t)
 


### PR DESCRIPTION
So EditorConfig removes trailing white space at saving a file. Sometimes this behavior conflicts my editings.