### PR TITLE
Do not automatically hide by hideshow on emacs-lisp-mode

### DIFF
--- a/init.el
+++ b/init.el
@@ -686,8 +686,7 @@
     :config
     (defun elim:emacs-lisp-mode-hook-func ()
       (set-variable 'indent-tabs-mode nil)
-      (hs-minor-mode +1)
-      (hs-hide-level 3)))
+      (hs-minor-mode +1)))
   (leaf git-modes :el-get magit/git-modes)
   (leaf go-mode
     :ensure t


### PR DESCRIPTION
It's hard to find it when it's hidden.